### PR TITLE
Except typerror. Closes #12.

### DIFF
--- a/tesla.30m.py
+++ b/tesla.30m.py
@@ -309,6 +309,10 @@ def main():
             abort_credentials()
             return
         raise
+    except TypeError as e:
+        abort_credentials()
+        return
+        raise
 
     # see if args are passed, if so, pass commands and bail
     if len(sys.argv) > 1:


### PR DESCRIPTION
Prompts the user to login again if a TypeError is thrown.